### PR TITLE
Alternative partial derivative calculation for interpolation

### DIFF
--- a/HealpixObj.f90
+++ b/HealpixObj.f90
@@ -1934,12 +1934,21 @@
 
     end subroutine  HealpixInterpLensedMap
 
-    subroutine  HealpixInterpLensedMap_GradPhi(H,A, GradPhi,M, factor, interp_method)
+    subroutine  HealpixInterpLensedMap_GradPhi(H,A, GradPhi,M, factor, interp_method, interp_algo)
     Type (HealpixInfo) :: H
     Type(HealpixMap) :: GradPhi, M
     Type(HealpixAlm), intent(in) :: A
     real, intent(in) :: factor
     integer, intent(in) :: interp_method
+    integer, intent(in), optional :: interp_algo
+    integer algo
+    
+    !By default use toms760 partial derivative scheme
+    if(present(interp_algo)) then
+        algo = interp_algo
+    else
+        algo = 1
+    endif
 
     call HealpixMap_Init(M,GradPhi%npix,nmaps = A%npol)
     if (GradPhi%spin /=1) call MpiStop('HealpixExactLensedMap: GradPhi must be spin 1 field')
@@ -1956,7 +1965,7 @@
         if (interp_method==interp_basic) then
             call alm2LensedmapInterp(H, A%lmax, A%TEB, GradPhi%SpinField, M%TQU, nint(factor))
         else
-            call alm2LensedmapInterpCyl(H, A%lmax, A%TEB, GradPhi%SpinField, M%TQU, factor)
+            call alm2LensedmapInterpCyl(H, A%lmax, A%TEB, GradPhi%SpinField, M%TQU, factor, algo)
         end if
     end if
     end subroutine  HealpixInterpLensedMap_GradPhi

--- a/HealpixObj.f90
+++ b/HealpixObj.f90
@@ -1133,7 +1133,7 @@
                 if (wantpol >=3 .and. l>=2) then
                     Examp = (P%PhiCl(l,3)-corr*P%cl(l,C_C))*sqrt( tamp/(p%cl(l,C_E)*tamp - p%cl(l,C_C)**2))
                     !To protect against numerical artifacts if CTT*CEE - CTE^2 <= 0
-                    if (Examp .ne. Examp) then
+                    if (p%cl(l, C_T)*p%cl(l, C_E) - p%cl(l, C_C)**2 .lt. 0.d0) then
                         Examp = 0.
                     endif
                     xamp = sqrt(max(0._sp, P%PhiCl(l,1) - corr*P%PhiCl(l,2) - Examp**2 ))

--- a/HealpixObj.f90
+++ b/HealpixObj.f90
@@ -1043,8 +1043,8 @@
         call InitRandom(seed)
     else
         if (.not. RandInited) call InitRandom
-        RandInited = .true.
     end if
+    RandInited = .true.
 
     wantpol = 1
 
@@ -1157,8 +1157,8 @@
         call InitRandom(seed)
     else
         if (.not. RandInited) call InitRandom
-        RandInited = .true.
     end if
+    RandInited = .true.
     call HealpixAlm_Init(A,P%lmax, 0,HasPhi = .true.)
     if (.not. P%lens) call MpiStop('must have phi power spectrum')
 

--- a/HealpixObj.f90
+++ b/HealpixObj.f90
@@ -1959,7 +1959,7 @@
         if (interp_method==interp_basic) then
             call scalalm2LensedmapInterp(H, A%lmax, A%TEB, GradPhi%SpinField, M%TQU, nint(factor))
         else
-            call scalalm2LensedmapInterpCyl(H, A%lmax, A%TEB, GradPhi%SpinField, M%TQU, factor)
+            call scalalm2LensedmapInterpCyl(H, A%lmax, A%TEB, GradPhi%SpinField, M%TQU, factor, algo)
         end if
     else
         if (interp_method==interp_basic) then

--- a/SimLens.f90
+++ b/SimLens.f90
@@ -21,7 +21,7 @@
     integer, parameter :: lens_interp =1, lens_exact = 2
     integer :: lens_method = lens_interp
     integer :: mpi_division_method = division_equalrows
-    integer ::  interp_method,  rand_seed
+    integer ::  interp_method,  rand_seed, interp_algo
     logical :: err, want_pol
     real :: interp_factor
     integer status
@@ -51,6 +51,7 @@
     rand_seed = Ini_Read_Int('rand_seed')
 
     interp_method = Ini_read_int('interp_method')
+    interp_algo = Ini_read_int('interp_algo')
 
     Ini_Fail_On_Not_Found = .false.
 
@@ -64,8 +65,14 @@
 
     call Ini_Close
 
-    file_stem =  trim(out_file_root)//'_lmax'//trim(IntToStr(lmax))//'_nside'//trim(IntTOStr(nside))// &
-    '_interp'//trim(RealToStr(interp_factor,3))//'_method'//trim(IntToStr(interp_method))//'_'
+    if (interp_algo == 1) then
+        file_stem =  trim(out_file_root)//'_lmax'//trim(IntToStr(lmax))//'_nside'//trim(IntTOStr(nside))// &
+        '_interp'//trim(RealToStr(interp_factor,3))//'_method'//trim(IntToStr(interp_method))//'_'
+    else
+        file_stem =  trim(out_file_root)//'_lmax'//trim(IntToStr(lmax))//'_nside'//trim(IntTOStr(nside))// &
+        '_interp'//trim(RealToStr(interp_factor,3))//'_method'//trim(IntToStr(interp_method))//'_algo'//&
+        trim(IntToStr(interp_algo))//'_'
+    endif
 
     if (want_pol) file_stem=trim(file_stem)//'pol_'
     file_stem = trim(file_stem)//trim(IntToStr(lens_method)) 
@@ -108,7 +115,7 @@
         if (lens_method == lens_exact) then
             call HealpixExactLensedMap_GradPhi(H,A,GradPhi,M)
         else if (lens_method == lens_interp) then
-            call HealpixInterpLensedMap_GradPhi(H,A,GradPhi, M, interp_factor, interp_method)
+            call HealpixInterpLensedMap_GradPhi(H,A,GradPhi, M, interp_factor, interp_method, interp_algo)
         else
             stop 'unknown lens_method'
         end if

--- a/params.ini
+++ b/params.ini
@@ -23,6 +23,11 @@ lens_method = 1
 # - for high accuracy probably need interp_factor ~ 2048/nside*1.5
 interp_factor = 1.5
 
+#1 calculates partial derivatives of the unlensed fields as in the original toms760 interpolation routine, 
+#2 uses faster but less precise (for a given interp_factor) calculation. Can be combined with increasing
+#interp_factor for an absolute speed-up
+interp_algo = 1
+
 #1 is using bicubic in equi-cylindical pixels, 0 is naive healpix remapping
 interp_method = 1
 

--- a/spin_alm_tools.f90
+++ b/spin_alm_tools.f90
@@ -5075,7 +5075,8 @@
     INTEGER(I4B) :: mmax_ring,par_lm, nlmax
 
     COMPLEX(SPC) :: this_grad
-    REAL(SP), dimension(:), allocatable ::  ring, theta_vals, &
+    REAL(SP), dimension(:), allocatable ::  ring
+    REAL(DP), dimension(:), allocatable ::  theta_vals, &
     phi_vals,theta_lensed_vals,phi_lensed_vals
 
     integer(I4B) high_nside
@@ -5483,7 +5484,8 @@
 
     REAL(DP), dimension(:), allocatable :: lam_fact
 
-    REAL(SP), dimension(:), allocatable ::  ring, theta_vals, &
+    REAL(SP), dimension(:), allocatable ::  ring
+    REAL(DP), dimension(:), allocatable ::  theta_vals, &
     phi_vals,theta_lensed_vals,phi_lensed_vals
 
     COMPLEX(SP), dimension(:), allocatable ::  polrot

--- a/spin_alm_tools.f90
+++ b/spin_alm_tools.f90
@@ -178,7 +178,7 @@
         COMPLEX(SPC), dimension(:), pointer :: grad_phiN => NULL() , grad_phiS => NULL()
     end  Type LensGradients
 
-    integer, parameter :: interp_edge = 2
+    integer, parameter :: interp_edge = 4
     !number of high-res pixels to go outside deflected region to get good interpolation
 
     integer, parameter :: EB_sign = -1

--- a/toms760.f90
+++ b/toms760.f90
@@ -5,24 +5,25 @@ MODULE Grid_Interpolation
 !      VOL. 22, NO. 3, September, 1996, P.  357--361.
 !AL Jun 2014: fixed f90 reshape
 IMPLICIT NONE
+INTEGER, PARAMETER, public :: dp  = SELECTED_REAL_KIND(12,200)
 
 Type Grid_Interpolation_Data
      REAL, pointer :: wk(:,:,:) => NULL()
-     REAL, pointer :: x(:), y(:)
+     REAL(DP), pointer :: x(:), y(:)
      integer nx, ny     
     
 end Type Grid_Interpolation_Data
 
 
-integer, parameter :: GI = KIND(1.0)
+integer, parameter :: GI = KIND(1.0d0)
 
 CONTAINS
 
 !Utility wrappers by AL, 2012
 subroutine Grid_Interpolation_Init(W, x,y, z)
  Type(Grid_Interpolation_Data):: W
- REAL, INTENT(IN)      :: x(:)
- REAL, INTENT(IN)      :: y(:)
+ REAL(DP), INTENT(IN)      :: x(:)
+ REAL(DP), INTENT(IN)      :: y(:)
  REAL, INTENT(IN)  :: z(:,:)
  
  W%nx = size(x)
@@ -46,8 +47,10 @@ end subroutine Grid_Interpolation_Free
 
 function Grid_Interpolate(W,zin, x,y) result (res)
   Type(Grid_Interpolation_Data) :: W
-  real res, z(1), xx(1),yy(1)
-  real, intent(in) :: x,y, zin(:,:)
+  real res, z(1)
+  real(DP) xx(1),yy(1)
+  real(DP), intent(in) :: x,y
+  real, intent(in) :: zin(:,:)
   integer md,ier
   
   md=2
@@ -63,7 +66,8 @@ subroutine Grid_InterpolatePoints(W, zin, nip, x,y,z)
   Type(Grid_Interpolation_Data) :: W
   integer, intent(in) :: nip
   real, intent(out):: z(*)
-  real, intent(in) :: x(*),y(*), zin(:,:)
+  real, intent(in) :: zin(:,:)
+  real(dp), intent(in) :: x(*),y(*)
   integer md,ier
   
   md=2
@@ -153,12 +157,12 @@ SUBROUTINE rgbi3p(Wk,md, nxd, nyd, xd, yd, zd, nip, xi, yi, zi, ier)
 INTEGER, INTENT(IN)   :: md
 INTEGER, INTENT(IN)   :: nxd
 INTEGER, INTENT(IN)   :: nyd
-REAL, INTENT(IN)      :: xd(nxd)
-REAL, INTENT(IN)      :: yd(nyd)
+REAL(DP), INTENT(IN)      :: xd(nxd)
+REAL(DP), INTENT(IN)      :: yd(nyd)
 REAL, INTENT(IN)  :: zd(nxd,nyd)
 INTEGER, INTENT(IN)   :: nip
-REAL, INTENT(IN)  :: xi(nip)
-REAL, INTENT(IN)  :: yi(nip)
+REAL(DP), INTENT(IN)  :: xi(nip)
+REAL(DP), INTENT(IN)  :: yi(nip)
 REAL, INTENT(OUT)  :: zi(nip)
 INTEGER, INTENT(OUT)  :: ier
 REAL, INTENT(INOUT)  :: wk(3,nxd,nyd)
@@ -326,13 +330,13 @@ SUBROUTINE rgsf3p(wk, md, nxd, nyd, xd, yd, zd, nxi, xi, nyi, yi, zi, ier)
 INTEGER, INTENT(IN)   :: md
 INTEGER, INTENT(IN)   :: nxd
 INTEGER, INTENT(IN)   :: nyd
-REAL, INTENT(IN)      :: xd(nxd)
-REAL, INTENT(IN)      :: yd(nyd)
+REAL(DP), INTENT(IN)      :: xd(nxd)
+REAL(DP), INTENT(IN)      :: yd(nyd)
 REAL, INTENT(IN OUT)  :: zd(nxd,nyd)
 INTEGER, INTENT(IN)   :: nxi
-REAL, INTENT(IN OUT)  :: xi(nxi)
+REAL(DP), INTENT(IN OUT)  :: xi(nxi)
 INTEGER, INTENT(IN)   :: nyi
-REAL, INTENT(IN)      :: yi(nyi)
+REAL(DP), INTENT(IN)      :: yi(nyi)
 REAL, INTENT(IN OUT)  :: zi(nxi,nyi)
 INTEGER, INTENT(OUT)  :: ier
 REAL, INTENT(INOUT)  :: wk(3,nxd,nyd)
@@ -344,7 +348,7 @@ INTEGER, PARAMETER  :: nipimx=51
 INTEGER  :: ix, ixi, iy, iyi, nipi
 !     ..
 !     .. Local Arrays ..
-REAL     :: yii(nipimx)
+REAL(DP) :: yii(nipimx)
 INTEGER  :: inxi(nipimx), inyi(nipimx)
 
 !     ..
@@ -497,8 +501,8 @@ SUBROUTINE rgpd3p(nxd, nyd, xd, yd, zd, pdd)
 
 INTEGER, INTENT(IN)  :: nxd
 INTEGER, INTENT(IN)  :: nyd
-REAL, INTENT(IN)     :: xd(nxd)
-REAL, INTENT(IN)     :: yd(nyd)
+REAL(DP), INTENT(IN)     :: xd(nxd)
+REAL(DP), INTENT(IN)     :: yd(nyd)
 REAL, INTENT(IN)     :: zd(nxd,nyd)
 REAL, INTENT(OUT)    :: pdd(3,nxd,nyd)
 
@@ -983,17 +987,17 @@ SUBROUTINE rglctn(nxd, nyd, xd, yd, nip, xi, yi, inxi, inyi)
 
 INTEGER, INTENT(IN)   :: nxd
 INTEGER, INTENT(IN)   :: nyd
-REAL, INTENT(IN)      :: xd(nxd)
-REAL, INTENT(IN)      :: yd(nyd)
+REAL(DP), INTENT(IN)      :: xd(nxd)
+REAL(DP), INTENT(IN)      :: yd(nyd)
 INTEGER, INTENT(IN)   :: nip
-REAL, INTENT(IN)      :: xi(nip)
-REAL, INTENT(IN)      :: yi(nip)
+REAL(DP), INTENT(IN)      :: xi(nip)
+REAL(DP), INTENT(IN)      :: yi(nip)
 INTEGER, INTENT(OUT)  :: inxi(nip)
 INTEGER, INTENT(OUT)  :: inyi(nip)
 
 !     ..
 !     .. Local Scalars ..
-REAL     :: xii, yii
+REAL(DP)     :: xii, yii
 INTEGER  :: iip, imd, imn, imx, ixd, iyd, nintx, ninty
 
 !     ..
@@ -1133,13 +1137,13 @@ SUBROUTINE rgplnl(nxd, nyd, xd, yd, zd, pdd, nip, xi, yi, inxi, inyi, zi)
 
 INTEGER, INTENT(IN)  :: nxd
 INTEGER, INTENT(IN)  :: nyd
-REAL, INTENT(IN)     :: xd(nxd)
-REAL, INTENT(IN)     :: yd(nyd)
+REAL(DP), INTENT(IN)     :: xd(nxd)
+REAL(DP), INTENT(IN)     :: yd(nyd)
 REAL, INTENT(IN)     :: zd(nxd,nyd)
 REAL, INTENT(IN)     :: pdd(3,nxd,nyd)
 INTEGER, INTENT(IN)  :: nip
-REAL, INTENT(IN)     :: xi(nip)
-REAL, INTENT(IN)     :: yi(nip)
+REAL(DP), INTENT(IN)     :: xi(nip)
+REAL(DP), INTENT(IN)     :: yi(nip)
 INTEGER, INTENT(IN)  :: inxi(nip)
 INTEGER, INTENT(IN)  :: inyi(nip)
 REAL, INTENT(OUT)    :: zi(nip)


### PR DESCRIPTION
Major change is allowing the user to choose alternative way how to calculate the partial derivatives for interpolation (less precise / faster than original toms760).

Further minor changes:
* Random number generator now labeled as initialized even when using seed
* Makes sure results are sensible even if input unlensed cmb has CTT*CEE < CTE**2
* Moved interpolation x, y to double precision to avoid certain map artifacts
* Increased interp_edge to have correct behavior around the edges